### PR TITLE
Correct includes value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Allows for non interrupting lighting effects for single LED's.
 category=Other
 url=https://github.com/SethSenpai/singleLEDLibrary
 architectures=*
-includes=
+includes=singleLEDLibrary.h


### PR DESCRIPTION
The `includes` field in library.properties is used to specify which `#include` directives should be added to the sketch via **Sketch > Include Library > Single LED Library**. Leaving this field empty causes that action to add the following line to the sketch:
```
#include <>
```