### PR TITLE
Use semver compliant version in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Single LED Library
-version=v1.0.1
+version=1.0.1
 author=Pim Ostendorf <contact@pimostendorf.nl>
 maintainer=Pim Ostendorf <contact@pimostendorf.nl>
 sentence=Makes intergrating non interrupting lighting behaviours easy!


### PR DESCRIPTION
Non-semver compliant `version` value causes the Arduino IDE to display warnings:
```
Invalid version found: v1.0.1
```
This can be especially confusing for users since the Arduino IDE doesn't say which library is the source of the problem.

References:
- https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format
- https://semver.org/